### PR TITLE
Fix incorrect call to draw.text

### DIFF
--- a/SMW-BizHawk.lua
+++ b/SMW-BizHawk.lua
@@ -2945,7 +2945,7 @@ function RNG.display()
       y = y + height
     end
   else
-    draw.text(x, y, "Glitched RNG! Report state/movie", "red")
+    draw.text(x, y, "Glitched RNG! Report state/movie", COLOUR.warning)
   end
 end
 


### PR DESCRIPTION
This would throw an error and stop the script upon getting hit. Only `gui.text` supports string color names, `draw.text` does not.